### PR TITLE
fix:Add missing change to .NET 10.6.0 release

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-6-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-6-0.mdx
@@ -20,6 +20,7 @@ As of this release, the oldest supported version is [.NET agent 8.24.244.0](/doc
 * RestSharp client instrumentation support has been extended to include the following versions: 106.11.x, 106.12.0, 106.13.0, and 106.15.0. [#1352](https://github.com/newrelic/newrelic-dotnet-agent/pull/1352)
 * RestSharp client instrumentation has been verified for versions 107.x and 108.x. For newer versions of RestSharp, external segments/spans are actually generated via our instrumentation of HttpClient. [#1356](https://github.com/newrelic/newrelic-dotnet-agent/pull/1356)
 * .NET TLS options are now logged during startup. [#1357](https://github.com/newrelic/newrelic-dotnet-agent/pull/1357)
+* StackExchange.Redis versions 2 and above use a new wrapper with improved performance and reduced network overhead. [#1351](https://github.com/newrelic/newrelic-dotnet-agent/pull/1351)
 
 Once published, the release artifacts for this release can be found [here](https://download.newrelic.com/dot_net_agent/latest_release/) or on NuGet.org.
 


### PR DESCRIPTION
## Give us some context

Adds the missing StackExchange.Redis changelog item to the release notes.